### PR TITLE
[FAK-19] Fix Kafka topic mismatch, Cloudinary hostname typo, WebSocket listener leak, and dev port config

### DIFF
--- a/api-gateway/.env
+++ b/api-gateway/.env
@@ -1,9 +1,3 @@
-# Environment variables declared in this file are automatically made available to Prisma.
-# See the documentation for more detail: https://pris.ly/d/prisma-schema#accessing-environment-variables-from-the-schema
-
-# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
-# See the documentation for all the connection string options: https://pris.ly/d/connection-strings
-
 DATABASE_URL="postgresql://auth_db:123456@localhost:5432/auth_db?schema=public"
-JWT_SECRET="JWT_SECRET"
-JWT_REFRESH_SECRET="JWT_REFRESH_SECRET"
+JWT_SECRET=fakebook_jwt_secret_dev
+JWT_REFRESH_SECRET=fakebook_jwt_refresh_secret_dev

--- a/api-gateway/.env
+++ b/api-gateway/.env
@@ -1,3 +1,0 @@
-DATABASE_URL="postgresql://auth_db:123456@localhost:5432/auth_db?schema=public"
-JWT_SECRET=fakebook_jwt_secret_dev
-JWT_REFRESH_SECRET=fakebook_jwt_refresh_secret_dev

--- a/api-gateway/.env.example
+++ b/api-gateway/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL="postgresql://<user>:<password>@localhost:5432/auth_db?schema=public"
+JWT_SECRET=<your-jwt-secret>
+JWT_REFRESH_SECRET=<your-jwt-refresh-secret>

--- a/api-gateway/src/main.ts
+++ b/api-gateway/src/main.ts
@@ -9,7 +9,7 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.setGlobalPrefix('/api');
   app.enableCors({
-    origin: 'http://localhost',
+    origin: 'http://localhost:3005',
     credentials: true
   });
   app.use(cookieParser());

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -1,12 +1,12 @@
-{
-  "parser": "@typescript-eslint/parser",
-  "parserOptions": {
-    "project": ["tsconfig.json"],
-    "tsconfigRootDir": "./",
-    "ecmaVersion": "latest",
-    "sourceType": "module"
+module.exports = {
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    project: ["tsconfig.json"],
+    tsconfigRootDir: __dirname,
+    ecmaVersion: "latest",
+    sourceType: "module"
   },
-  "extends": [
+  extends: [
     "prettier",
     "next/core-web-vitals",
     "next",
@@ -14,8 +14,8 @@
     "plugin:@typescript-eslint/recommended",
     "plugin:prettier/recommended"
   ],
-  "plugins": ["@typescript-eslint"],
-  "rules": {
+  plugins: ["@typescript-eslint"],
+  rules: {
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": ["warn"],
     "@typescript-eslint/explicit-module-boundary-types": "off",
@@ -23,4 +23,4 @@
     "@typescript-eslint/no-empty-object-type": "off",
     "react-hooks/exhaustive-deps": "off"
   }
-}
+};

--- a/client/components/common/NotificationPopup.tsx
+++ b/client/components/common/NotificationPopup.tsx
@@ -27,16 +27,8 @@ const NotificationPopup: React.FC<NotificationPopupProps> = ({
   const [visible, setVisible] = useState(true);
   const [hovered, setHovered] = useState(false);
   const [shouldRender, setShouldRender] = useState(true);
-  const {
-    mutate: acceptFriendRequest,
-    isError: isAcceptError,
-    error: acceptError
-  } = useAcceptFriendRequest(String(user?.id));
-  const {
-    mutate: declineFriendRequest,
-    isError: isDeclineError,
-    error: declineError
-  } = useDeclineFriendRequest(String(user?.id));
+  const { mutate: acceptFriendRequest } = useAcceptFriendRequest(String(user?.id));
+  const { mutate: declineFriendRequest } = useDeclineFriendRequest(String(user?.id));
 
   const timerRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -62,24 +54,44 @@ const NotificationPopup: React.FC<NotificationPopupProps> = ({
     }
   }, [visible]);
 
-  useEffect(() => {
-    toast.error(acceptError?.message);
-  }, [isAcceptError]);
-
-  useEffect(() => {
-    toast.error(declineError?.message);
-  }, [isDeclineError]);
-
   const handleAccept = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
-    acceptFriendRequest({ friendId: senderId });
-    setShouldRender(false);
+    if (!user?.id) {
+      toast.error('User information not loaded yet');
+      return;
+    }
+    acceptFriendRequest(
+      { friendId: senderId },
+      {
+        onSuccess: () => {
+          toast.success('Friend request accepted!');
+          setShouldRender(false);
+        },
+        onError: (err: any) => {
+          toast.error(err?.message || 'Failed to accept friend request');
+        }
+      }
+    );
   };
 
   const handleDecline = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
-    declineFriendRequest({ friendId: senderId });
-    setShouldRender(false);
+    if (!user?.id) {
+      toast.error('User information not loaded yet');
+      return;
+    }
+    declineFriendRequest(
+      { friendId: senderId },
+      {
+        onSuccess: () => {
+          toast.success('Friend request declined');
+          setShouldRender(false);
+        },
+        onError: (err: any) => {
+          toast.error(err?.message || 'Failed to decline friend request');
+        }
+      }
+    );
   };
 
   if (!shouldRender) return null;

--- a/client/components/common/NotificationPopup.tsx
+++ b/client/components/common/NotificationPopup.tsx
@@ -67,7 +67,7 @@ const NotificationPopup: React.FC<NotificationPopupProps> = ({
           toast.success('Friend request accepted!');
           setShouldRender(false);
         },
-        onError: (err: any) => {
+        onError: (err: Error) => {
           toast.error(err?.message || 'Failed to accept friend request');
         }
       }
@@ -87,7 +87,7 @@ const NotificationPopup: React.FC<NotificationPopupProps> = ({
           toast.success('Friend request declined');
           setShouldRender(false);
         },
-        onError: (err: any) => {
+        onError: (err: Error) => {
           toast.error(err?.message || 'Failed to decline friend request');
         }
       }

--- a/client/components/providers/WebSocketProvider.tsx
+++ b/client/components/providers/WebSocketProvider.tsx
@@ -17,28 +17,40 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
   useEffect(() => {
     if (!user?.id) return;
 
-    if (!notificationSocket.connected) notificationSocket.connect();
-
-    notificationSocket.on('connect', () => {
+    const onConnect = () => {
       console.log('Connected to WebSocket server');
-      const userId = user.id;
-      notificationSocket.emit('join', userId);
-    });
+      notificationSocket.emit('join', user.id);
+    };
 
-    notificationSocket.on('connect_error', err => {
-      console.error('Connection error:', err);
-    });
-
-    notificationSocket.on('disconnect', () => {
-      console.log('Disconnected from WebSocket server');
-    });
-
-    notificationSocket.on('new-notification', data => {
+    const onNotification = (data: INotification) => {
       console.log('New notification received:', data);
       setNotification(data);
-    });
+    };
+
+    const onConnectError = (err: any) => {
+      console.error('Connection error:', err);
+    };
+
+    const onDisconnect = () => {
+      console.log('Disconnected from WebSocket server');
+    };
+
+    if (notificationSocket.connected) {
+      onConnect();
+    } else {
+      notificationSocket.connect();
+    }
+
+    notificationSocket.on('connect', onConnect);
+    notificationSocket.on('connect_error', onConnectError);
+    notificationSocket.on('disconnect', onDisconnect);
+    notificationSocket.on('new-notification', onNotification);
 
     return () => {
+      notificationSocket.off('connect', onConnect);
+      notificationSocket.off('connect_error', onConnectError);
+      notificationSocket.off('disconnect', onDisconnect);
+      notificationSocket.off('new-notification', onNotification);
       notificationSocket.disconnect();
     };
   }, [user?.id]);

--- a/client/next.config.js
+++ b/client/next.config.js
@@ -7,7 +7,7 @@ const nextConfig = {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: 'res.cloudinary.comm',
+        hostname: 'res.cloudinary.com',
         port: '',
         pathname: '/fakebook-2025/image/upload/*'
       }

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "npm run lint:fix && next dev -p 3005",
+    "dev": "next dev -p 3005",
+    "dev:lint": "npm run lint:fix && next dev -p 3005",
     "build": "next build",
     "start": "next start -p 3005",
     "lint": "next lint",

--- a/client/package.json
+++ b/client/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "npm run lint:fix && next dev -p 80",
+    "dev": "npm run lint:fix && next dev -p 3005",
     "build": "next build",
-    "start": "next start -p 80",
+    "start": "next start -p 3005",
     "lint": "next lint",
     "lint:fix": "eslint --fix --ext ts,tsx .",
     "prettier": "prettier --check \"**/(**.tsx|*.ts|*.scss|*.css)\"",

--- a/dev.sh
+++ b/dev.sh
@@ -37,6 +37,10 @@ for svc in "${SERVICES[@]}"; do
     echo "WARNING: directory '$svc' not found, skipping."
     continue
   fi
+  if [[ ! -d "$svc/node_modules" ]]; then
+    echo "WARNING: $svc/node_modules not found — run 'npm install' inside $svc first, skipping."
+    continue
+  fi
   echo "Starting $svc..."
   (cd "$svc" && npm run start:dev 2>&1 | sed "s/^/[$svc] /") &
   PIDS+=($!)
@@ -44,4 +48,11 @@ done
 
 echo ""
 echo "All services started. Press Ctrl+C to stop."
+
+# Give services a moment to start, then check none exited immediately
+sleep 3
+for pid in "${PIDS[@]}"; do
+  kill -0 "$pid" 2>/dev/null || echo "WARNING: a service exited early (PID $pid) — check logs above"
+done
+
 wait

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Start all fakebook services in dev mode.
+# Usage: ./dev.sh [--infra-only]
+#
+# Requires: npm, Node.js. Infra must be running (docker compose up -d).
+
+set -e
+
+SERVICES=(user-service api-gateway image-service notification-service ws-service client)
+PIDS=()
+
+cleanup() {
+  echo ""
+  echo "Stopping all services..."
+  for pid in "${PIDS[@]}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+  wait
+  echo "Done."
+}
+trap cleanup SIGINT SIGTERM
+
+if [[ "$1" == "--infra-only" ]]; then
+  docker compose up -d
+  echo "Infrastructure started."
+  exit 0
+fi
+
+# Ensure infra is up
+docker compose up -d
+echo "Infrastructure ready."
+echo ""
+
+# Start each service in the background, prefix logs with service name
+for svc in "${SERVICES[@]}"; do
+  if [[ ! -d "$svc" ]]; then
+    echo "WARNING: directory '$svc' not found, skipping."
+    continue
+  fi
+  echo "Starting $svc..."
+  (cd "$svc" && npm run start:dev 2>&1 | sed "s/^/[$svc] /") &
+  PIDS+=($!)
+done
+
+echo ""
+echo "All services started. Press Ctrl+C to stop."
+wait

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,143 @@
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: fakebook-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    restart: unless-stopped
+
+  neo4j:
+    image: neo4j:5
+    container_name: fakebook-neo4j
+    ports:
+      - "7474:7474"   # browser UI
+      - "7687:7687"   # bolt
+    environment:
+      NEO4J_AUTH: neo4j/neo4j_password
+    volumes:
+      - neo4j_data:/data
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:16-alpine
+    container_name: fakebook-postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: fakebook
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
+  # OLD (Zookeeper mode — Kafka ≤ 3.x with external coordinator)
+  # ---------------------------------------------------------------------------
+  # Zookeeper was a separate process that every Kafka broker had to connect to.
+  # It stored cluster metadata (broker list, topic configs, partition leaders,
+  # ACLs) and ran leader-election. Drawbacks: extra service to run/monitor,
+  # metadata ops go through a network round-trip, and scaling beyond ~200k
+  # partitions became painful.
+  #
+  # zookeeper:
+  #   image: confluentinc/cp-zookeeper:7.6.0
+  #   container_name: fakebook-zookeeper
+  #   environment:
+  #     ZOOKEEPER_CLIENT_PORT: 2181   # port brokers connect to
+  #     ZOOKEEPER_TICK_TIME: 2000     # heartbeat interval in ms
+  #   restart: unless-stopped
+  #
+  # kafka-1:
+  #   image: confluentinc/cp-kafka:7.6.0
+  #   depends_on:
+  #     - zookeeper                   # must wait for ZK before starting
+  #   environment:
+  #     KAFKA_BROKER_ID: 1                       # static integer, set manually
+  #     KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181  # tells broker where ZK is
+  #     KAFKA_LISTENERS: INTERNAL://0.0.0.0:29092,EXTERNAL://0.0.0.0:9092
+  #     KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-1:29092,EXTERNAL://localhost:9092
+  #     KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+  #     KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+  #     KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 2
+  #     KAFKA_DEFAULT_REPLICATION_FACTOR: 2
+  # ---------------------------------------------------------------------------
+
+  # ---------------------------------------------------------------------------
+  # NEW (KRaft mode — Kafka 3.3+, no Zookeeper)
+  # ---------------------------------------------------------------------------
+  # KRaft (Kafka Raft) moves metadata management inside Kafka itself. Each
+  # broker can now also act as a "controller" (the role ZK used to fill).
+  # Controllers use the Raft consensus algorithm to elect a leader and replicate
+  # the cluster metadata log — no external process needed.
+  # ---------------------------------------------------------------------------
+
+  kafka-1:
+    image: confluentinc/cp-kafka:7.7.1
+    container_name: fakebook-kafka-1
+    ports:
+      - "9092:9092"
+    environment:
+      # Shared UUID that identifies this cluster. All brokers in the same
+      # cluster must use the identical value. Generated once with:
+      #   docker run --rm confluentinc/cp-kafka:7.7.1 kafka-storage random-uuid
+      CLUSTER_ID: 'MkU3OEVBNTcwNTJENDM2Qk'
+
+      # Replaces KAFKA_BROKER_ID. Must be unique per node and must match the
+      # IDs listed in KAFKA_CONTROLLER_QUORUM_VOTERS.
+      KAFKA_NODE_ID: 1
+
+      # This node runs both a broker (serves producers/consumers) and a
+      # controller (participates in Raft metadata quorum). You can separate
+      # these roles onto dedicated nodes in large clusters.
+      KAFKA_PROCESS_ROLES: broker,controller
+
+      # The full list of controller nodes that form the Raft quorum.
+      # Format: <nodeId>@<host>:<controllerPort>
+      # With 2 nodes the quorum requires BOTH to be up (majority = 2/2).
+      # Use 3 nodes in production so you can tolerate one failure.
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@kafka-1:29091,2@kafka-2:29091'
+
+      # Three listeners on this broker:
+      #   CONTROLLER — used only for Raft traffic between controllers (port 29091)
+      #   INTERNAL   — broker-to-broker replication inside Docker (port 29092)
+      #   EXTERNAL   — client connections from the host machine (port 9092)
+      KAFKA_LISTENERS: CONTROLLER://0.0.0.0:29091,INTERNAL://0.0.0.0:29092,EXTERNAL://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-1:29092,EXTERNAL://localhost:9092
+
+      # CONTROLLER must be mapped here even though it is not advertised.
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+
+      # Tells the broker which listener name carries Raft (controller) traffic.
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 2
+      KAFKA_DEFAULT_REPLICATION_FACTOR: 2
+    restart: unless-stopped
+
+  kafka-2:
+    image: confluentinc/cp-kafka:7.7.1
+    container_name: fakebook-kafka-2
+    ports:
+      - "9093:9093"
+    environment:
+      CLUSTER_ID: 'MkU3OEVBNTcwNTJENDM2Qk'
+      KAFKA_NODE_ID: 2
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@kafka-1:29091,2@kafka-2:29091'
+      KAFKA_LISTENERS: CONTROLLER://0.0.0.0:29091,INTERNAL://0.0.0.0:29093,EXTERNAL://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-2:29093,EXTERNAL://localhost:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 2
+      KAFKA_DEFAULT_REPLICATION_FACTOR: 2
+    restart: unless-stopped
+
+volumes:
+  redis_data:
+  neo4j_data:
+  postgres_data:

--- a/image-service/.env.example
+++ b/image-service/.env.example
@@ -1,0 +1,7 @@
+KAFKA_BROKER_1=localhost:9092
+KAFKA_BROKER_2=localhost:9093
+
+CLOUDINARY_CLOUD_NAME=<your-cloud-name>
+CLOUDINARY_API_KEY=<your-api-key>
+CLOUDINARY_API_SECRET=<your-api-secret>
+CLOUDINARY_HOST=https://res.cloudinary.com/<your-cloud-name>/image/upload/

--- a/notification-service/.env.example
+++ b/notification-service/.env.example
@@ -1,0 +1,3 @@
+MONGODB_URI=mongodb+srv://<user>:<password>@<cluster>.mongodb.net/notification?appName=<app-name>
+WS_SERVICE_HOST=localhost
+WS_SERVICE_PORT=3002

--- a/notification-service/src/notification/notification.service.ts
+++ b/notification-service/src/notification/notification.service.ts
@@ -14,7 +14,7 @@ export class NotificationService {
     @InjectModel(Notification.name) private notificationModel: Model<Notification>,
     @Inject('WS_SERVICE') private readonly wsClient: ClientProxy,
     private userService: UserService
-  ) {}
+  ) { }
 
   getContent(type: string) {
     switch (type) {
@@ -31,7 +31,7 @@ export class NotificationService {
     const { sender, receiver, type } = payload;
     const content = this.getContent(type);
     const user = await this.userService.findByIds([sender]);
-    if (!user) {
+    if (!user || user.length === 0) {
       return formattedResponse('fail', 'User not found', undefined);
     }
     const senderAvatar = user[0].avatar;

--- a/user-service/.env.example
+++ b/user-service/.env.example
@@ -1,0 +1,12 @@
+NEO4J_HOST=bolt://localhost:7687
+NEO4J_USERNAME=neo4j
+NEO4J_PASSWORD=<your-neo4j-password>
+
+WS_SERVICE_HOST=localhost
+WS_SERVICE_PORT=3002
+
+KAFKA_BROKER_1=localhost:9092
+KAFKA_BROKER_2=localhost:9093
+
+DEFAULT_AVATAR_URL=<cloudinary-path-to-default-avatar>
+DEFAULT_COVER_URL=<cloudinary-path-to-default-cover>

--- a/user-service/src/user/user.module.ts
+++ b/user-service/src/user/user.module.ts
@@ -27,9 +27,6 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
             client: {
               clientId: 'notification',
               brokers: [configService.get<string>('KAFKA_BROKER_1'), configService.get<string>('KAFKA_BROKER_2')]
-            },
-            consumer: {
-              groupId: 'notification-consumer'
             }
           }
         }),

--- a/user-service/src/user/user.service.ts
+++ b/user-service/src/user/user.service.ts
@@ -170,7 +170,7 @@ export class UserService {
       const records = result.records;
       if (records.length === 0) return formattedResponse('fail');
       this.wsClient.emit('image-ready', { userId, imageUrl: url, type });
-      if (type === 'avatar') this.notificationClient.emit('update_user', new UpdateUserEvent(userId, null, url));
+      if (type === 'avatar') this.notificationClient.emit('update-user', new UpdateUserEvent(userId, null, url));
       return formattedResponse('success', undefined, records[0].get('u').properties);
     } catch (error) {
       console.error({ error });

--- a/ws-service/src/notification/notification.gateway.ts
+++ b/ws-service/src/notification/notification.gateway.ts
@@ -4,7 +4,7 @@ import { INotification, IUserImage } from './notification.interface';
 
 @WebSocketGateway(4000, {
   cors: {
-    origin: 'http://localhost'
+    origin: 'http://localhost:3005'
   },
   namespace: 'notification'
 })


### PR DESCRIPTION
## Summary
- Fix Kafka emit topic `update_user` → `update-user` so avatar changes correctly reach notification-service's user replica
- Fix Cloudinary hostname typo (`res.cloudinary.comm` → `res.cloudinary.com`) in `next.config.js` that blocked all image rendering
- Fix WebSocket named handler references in `WebSocketProvider` so `socket.off()` properly removes listeners on cleanup, preventing accumulation across re-renders
- Move accept/decline mutation success/error handling inline into callbacks; guard against missing `user.id`
- Safer null check `!user || user.length === 0` before accessing user array in notification-service
- Remove misplaced `consumer.groupId` from Kafka producer config in user-service
- Change dev port from `80` → `3005` across client, api-gateway CORS, and ws-service CORS — unblocks local dev without needing a reverse proxy
- Upgrade docker-compose Kafka from Zookeeper mode to KRaft (7.6.0 → 7.7.1), removing the Zookeeper dependency
- Add `dev.sh` to start all services and infra with a single command
- Rename `client/.eslintrc.json` → `.eslintrc.js`

## Jira
[FAK-19](https://nguyenphatdat3004.atlassian.net/browse/FAK-19)

[FAK-19]: https://nguyenphatdat3004.atlassian.net/browse/FAK-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ