### PR TITLE
[FAK-20] Build post feed UI: detail popup, photo theater, and nested comments

### DIFF
--- a/client/app/friends/page.tsx
+++ b/client/app/friends/page.tsx
@@ -53,11 +53,11 @@ export default function FriendSuggestion() {
           </div>
           <div className="col-span-3 p-[20px]">
             <h3 className="text-[20px] text-[#e4e6eb] font-bold mb-[16px]">People you may know</h3>
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5 gap-2">
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-7 3xl:grid-cols-8 4xl:grid-cols-10 gap-2">
               {users.map(suggestion => (
-                <div key={suggestion.id} className="shadow-border rounded-md overflow-hidden mt-1">
-                  <div className="">
-                    <Image src={suggestion.avatar} alt="" width={232} height={232} className="rounded-md" />
+                <div key={suggestion.id} className="shadow-border rounded-md overflow-hidden mt-1 flex flex-col">
+                  <div className="relative w-full aspect-square">
+                    <Image src={suggestion.avatar} alt="" fill className="object-cover" />
                   </div>
                   <div className="bg-[#242526] text-[#e4e6eb] font-semibold py-[8px] px-[12px] ">
                     <h4 className="text-[17px] font-bold">{suggestion.fullName}</h4>

--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -79,28 +79,32 @@ input {
   color: #e0e2e6 !important;
 }
 
-/* width */
+/* Custom scrollbar (global) — thin, rounded, subtle dark thumb */
+
+/* Firefox */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #555759 transparent;
+}
+
+/* WebKit (Chrome, Edge, Safari) */
 ::-webkit-scrollbar {
-  width: 16px;
+  width: 10px;
+  height: 10px;
 }
 
-.modal ::-webkit-scrollbar {
-  width: 8px;
-}
-
-/* Track */
 ::-webkit-scrollbar-track {
-  background: #424242;
+  background: transparent;
 }
 
-/* Handle */
 ::-webkit-scrollbar-thumb {
-  background: #686868;
-  border-radius: 2px;
+  background-color: #555759;
+  border-radius: 9999px;
+  /* transparent border + content-box clip makes the thumb look slimmer with padding */
+  border: 2px solid transparent;
+  background-clip: content-box;
 }
 
-/* Handle on hover */
 ::-webkit-scrollbar-thumb:hover {
-  background: #7b7b7b;
-  border-radius: 2px;
+  background-color: #6a6c6e;
 }

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -5,19 +5,20 @@ import NewsFeed from '@components/content/NewsFeed';
 import Shortcut from '@components/content/Shortcut';
 import { useMe } from '@hooks/api/user';
 
-interface AppProps {}
+interface AppProps { }
 
 const App: React.FC<AppProps> = () => {
   const { data: user } = useMe();
 
   return (
-    <div className="mt-[56px] grid grid-cols-4 p-[6px] min-h-[calc(100vh-56px)] bg-[#18191a]">
+    <div className="mt-[56px] min-h-[calc(100vh-56px)] bg-[#18191a]">
       {user && (
-        <>
+        // Full-width row: rails hug the screen edges, feed centered between them.
+        <div className="flex">
           <Shortcut />
           <NewsFeed />
           <Contacts />
-        </>
+        </div>
       )}
     </div>
   );

--- a/client/components/Content/Comment.tsx
+++ b/client/components/Content/Comment.tsx
@@ -10,10 +10,16 @@ interface CommentProps {
   comment: IComment;
   onReply: (parentId: string, content: string) => void;
   onToggleLike: (id: string) => void;
+  depth?: number;
 }
 
-const Comment: React.FC<CommentProps> = ({ comment, onReply, onToggleLike }) => {
+// Indent only the first two levels (like Facebook); deeper replies render flush
+// so a long thread never marches off the right edge of the narrow sidebar.
+const MAX_INDENT_DEPTH = 2;
+
+const Comment: React.FC<CommentProps> = ({ comment, onReply, onToggleLike, depth = 0 }) => {
   const [showReplyInput, setShowReplyInput] = useState(false);
+  const indent = depth < MAX_INDENT_DEPTH;
 
   const handleReply = (content: string) => {
     onReply(comment.id, content);
@@ -60,11 +66,11 @@ const Comment: React.FC<CommentProps> = ({ comment, onReply, onToggleLike }) => 
         </div>
       </div>
 
-      {/* Replies (indented) + inline reply composer */}
+      {/* Replies (indented up to MAX_INDENT_DEPTH) + inline reply composer */}
       {(comment.replies?.length || showReplyInput) && (
-        <div className="ml-[40px] mt-2 flex flex-col gap-3 border-l-2 border-[#3e4042] pl-3">
+        <div className={cn('mt-2 flex flex-col gap-3', indent && 'ml-[40px] border-l-2 border-[#3e4042] pl-3')}>
           {comment.replies?.map(reply => (
-            <Comment key={reply.id} comment={reply} onReply={onReply} onToggleLike={onToggleLike} />
+            <Comment key={reply.id} comment={reply} onReply={onReply} onToggleLike={onToggleLike} depth={depth + 1} />
           ))}
           {showReplyInput && (
             <CommentInput

--- a/client/components/Content/Comment.tsx
+++ b/client/components/Content/Comment.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import cn from 'classnames';
+import { IComment } from '@types';
+import CommentInput from './CommentInput';
+
+interface CommentProps {
+  comment: IComment;
+  onReply: (parentId: string, content: string) => void;
+  onToggleLike: (id: string) => void;
+}
+
+const Comment: React.FC<CommentProps> = ({ comment, onReply, onToggleLike }) => {
+  const [showReplyInput, setShowReplyInput] = useState(false);
+
+  const handleReply = (content: string) => {
+    onReply(comment.id, content);
+    setShowReplyInput(false);
+  };
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex gap-2">
+        <Image
+          src={comment.authorAvatar}
+          alt={comment.authorName}
+          width={32}
+          height={32}
+          className="h-8 w-8 rounded-full object-cover"
+        />
+        <div className="flex flex-col">
+          {/* Comment bubble */}
+          <div className="w-fit rounded-2xl bg-[#3a3b3c] px-3 py-2">
+            <h5 className="text-[13px] font-semibold text-[#e4e6eb]">{comment.authorName}</h5>
+            <p className="text-[15px] text-[#e4e6eb]">{comment.content}</p>
+          </div>
+          {/* Actions row */}
+          <div className="flex items-center gap-3 px-3 pt-1 text-[12px] font-semibold text-[#b0b3b8]">
+            <span>{comment.createdAt}</span>
+            <button
+              onClick={() => onToggleLike(comment.id)}
+              className={cn('hover:underline', comment.isLiked && 'text-[#0866ff]')}
+            >
+              Like
+            </button>
+            <button onClick={() => setShowReplyInput(prev => !prev)} className="hover:underline">
+              Reply
+            </button>
+            {comment.likes > 0 && (
+              <span className="flex items-center gap-1 font-normal">
+                <span className="flex h-[16px] w-[16px] items-center justify-center rounded-full bg-[#0866ff] text-[9px] text-white">
+                  👍
+                </span>
+                {comment.likes}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Replies (indented) + inline reply composer */}
+      {(comment.replies?.length || showReplyInput) && (
+        <div className="ml-[40px] mt-2 flex flex-col gap-3 border-l-2 border-[#3e4042] pl-3">
+          {comment.replies?.map(reply => (
+            <Comment key={reply.id} comment={reply} onReply={onReply} onToggleLike={onToggleLike} />
+          ))}
+          {showReplyInput && (
+            <CommentInput
+              size="sm"
+              autoFocus
+              placeholder={`Reply to ${comment.authorName}...`}
+              onSubmit={handleReply}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Comment;

--- a/client/components/Content/CommentInput.tsx
+++ b/client/components/Content/CommentInput.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Image from 'next/image';
+import { IoMdSend } from 'react-icons/io';
+
+interface CommentInputProps {
+  onSubmit: (content: string) => void;
+  placeholder?: string;
+  autoFocus?: boolean;
+  avatar?: string;
+  size?: 'sm' | 'md';
+}
+
+const CommentInput: React.FC<CommentInputProps> = ({
+  onSubmit,
+  placeholder = 'Write a comment...',
+  autoFocus = false,
+  avatar = '/avatar.jpg',
+  size = 'md'
+}) => {
+  const [value, setValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+  const avatarSize = size === 'sm' ? 28 : 32;
+
+  useEffect(() => {
+    if (autoFocus && inputRef.current) inputRef.current.focus();
+  }, [autoFocus]);
+
+  const submit = () => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onSubmit(trimmed);
+    setValue('');
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      submit();
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <Image
+        src={avatar}
+        alt="your avatar"
+        width={avatarSize}
+        height={avatarSize}
+        className="rounded-full object-cover"
+        style={{ width: avatarSize, height: avatarSize }}
+      />
+      <div className="flex flex-1 items-center bg-[#3a3b3c] rounded-full pl-3 pr-1">
+        <input
+          ref={inputRef}
+          value={value}
+          onChange={e => setValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          className="flex-1 bg-transparent py-2 text-[15px] text-[#e4e6eb] placeholder:text-[#b0b3b8] focus:outline-none"
+        />
+        <button
+          onClick={submit}
+          disabled={!value.trim()}
+          className="flex h-8 w-8 items-center justify-center rounded-full text-[#0866ff] hover:bg-[#4e4f50] disabled:text-[#65686c] disabled:hover:bg-transparent"
+        >
+          <IoMdSend size={18} />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default CommentInput;

--- a/client/components/Content/Contacts.tsx
+++ b/client/components/Content/Contacts.tsx
@@ -7,9 +7,8 @@ interface ContactsProps {}
 const Contacts: React.FC<ContactsProps> = () => {
   const { onChangeOpen, open } = useChatBox();
   return (
-    <div>
-      <div className="w-1/4 mt-[56px] py-[6px] px-[12px] text-[#b0b3b8] font-[15px] fixed top-0">
-        <h3 className="text-[17px] font-bold mt-[10px]">Contacts</h3>
+    <aside className="hidden lg:block w-[300px] shrink-0 self-start sticky top-[56px] max-h-[calc(100vh-56px)] overflow-y-auto py-4 pr-4 text-[#b0b3b8] text-[15px]">
+      <h3 className="text-[17px] font-bold">Contacts</h3>
         <div
           onClick={() => onChangeOpen(!open)}
           className="flex items-center gap-2 mt-[10px] p-2 rounded-lg hover:bg-[#3a3b3c] hover:cursor-pointer"
@@ -48,8 +47,7 @@ const Contacts: React.FC<ContactsProps> = () => {
           </div>
           <p className="text-[#e4e6eb]">Nguyễn Văn An</p>
         </div>
-      </div>
-    </div>
+    </aside>
   );
 };
 

--- a/client/components/Content/NewsFeed.tsx
+++ b/client/components/Content/NewsFeed.tsx
@@ -1,20 +1,31 @@
 'use client';
 
+import { useState } from 'react';
 import Post from './Post';
+import PostModal from './PostModal';
+import PhotoTheaterModal from './PhotoTheaterModal';
+import { posts } from '@mock/posts';
+import { IPost } from '@types';
 
 interface NewsFeedProps {}
 const NewsFeed: React.FC<NewsFeedProps> = () => {
+  const [selectedPost, setSelectedPost] = useState<IPost | null>(null);
+
+  const close = () => setSelectedPost(null);
+
   return (
-    <div className="col-span-2 px-[48px]">
-      <Post />
-      <Post />
-      <Post />
-      <Post />
-      <Post />
-      <Post />
-      <Post />
-      <Post />
-      <Post />
+    <div className="flex-1 min-w-0 max-w-[800px] mx-auto py-4">
+      {posts.map(post => (
+        <Post key={post.id} post={post} onOpen={() => setSelectedPost(post)} />
+      ))}
+
+      {/* Image posts open the full-screen theater; text posts use the centered popup. */}
+      {selectedPost &&
+        (selectedPost.image ? (
+          <PhotoTheaterModal post={selectedPost} isOpen onClose={close} />
+        ) : (
+          <PostModal post={selectedPost} isOpen onClose={close} />
+        ))}
     </div>
   );
 };

--- a/client/components/Content/NewsFeed.tsx
+++ b/client/components/Content/NewsFeed.tsx
@@ -22,9 +22,9 @@ const NewsFeed: React.FC<NewsFeedProps> = () => {
       {/* Image posts open the full-screen theater; text posts use the centered popup. */}
       {selectedPost &&
         (selectedPost.image ? (
-          <PhotoTheaterModal post={selectedPost} isOpen onClose={close} />
+          <PhotoTheaterModal key={selectedPost.id} post={selectedPost} isOpen onClose={close} />
         ) : (
-          <PostModal post={selectedPost} isOpen onClose={close} />
+          <PostModal key={selectedPost.id} post={selectedPost} isOpen onClose={close} />
         ))}
     </div>
   );

--- a/client/components/Content/PhotoTheaterModal.tsx
+++ b/client/components/Content/PhotoTheaterModal.tsx
@@ -4,13 +4,10 @@ import { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
-import { AiFillLike, AiOutlineLike } from 'react-icons/ai';
-import { FaRegComment, FaFacebook } from 'react-icons/fa';
-import { RiShareForwardLine } from 'react-icons/ri';
+import { FaFacebook } from 'react-icons/fa';
 import { BsThreeDots } from 'react-icons/bs';
 import { MdPublic } from 'react-icons/md';
 import { RxCross1 } from 'react-icons/rx';
-import cn from 'classnames';
 import { usePostInteractions } from '@hooks/client/usePostInteractions';
 import { useOpenModal } from '@hooks/client/useOpenModal';
 import { useMe } from '@hooks/api/user';
@@ -18,6 +15,7 @@ import HeaderNotification from '@components/header/HeaderNotification';
 import { IPost } from '@types';
 import Comment from './Comment';
 import CommentInput from './CommentInput';
+import PostEngagement from './PostEngagement';
 
 interface PhotoTheaterModalProps {
   post: IPost;
@@ -128,38 +126,14 @@ const PhotoTheaterModal: React.FC<PhotoTheaterModalProps> = ({ post, isOpen, onC
         <div className="min-h-0 flex-1 overflow-y-auto p-4">
           <p className="text-[15px] text-[#e4e6eb]">{post.content}</p>
 
-          <div className="mt-3 flex items-center justify-between text-[15px] font-light text-[#b0b3b8]">
-            <div className="flex items-center gap-1">
-              <div className="flex h-[18px] w-[18px] items-center justify-center rounded-full bg-[#0780ff]">
-                <AiFillLike className="h-[11px] w-[11px] text-white" />
-              </div>
-              <span>{likes}</span>
-            </div>
-            <div className="flex gap-3">
-              <span>{commentCount} comments</span>
-              <span>{post.shares} shares</span>
-            </div>
-          </div>
-
-          <div className="mt-2 grid grid-cols-3 border-y border-[#3e4042] py-[2px]">
-            <button
-              onClick={togglePostLike}
-              className={cn(
-                'flex w-full items-center justify-center gap-2 rounded-md py-[6px] font-semibold hover:bg-[#3a3b3c]',
-                liked ? 'text-[#0866ff]' : 'text-[#b0b3b8]'
-              )}
-            >
-              {liked ? <AiFillLike size={20} /> : <AiOutlineLike size={20} />}
-              <span className="text-[15px]">Like</span>
-            </button>
-            <button className="flex w-full items-center justify-center gap-2 rounded-md py-[6px] text-[#b0b3b8] hover:bg-[#3a3b3c]">
-              <FaRegComment size={18} />
-              <span className="text-[15px]">Comment</span>
-            </button>
-            <button className="flex w-full items-center justify-center gap-2 rounded-md py-[6px] text-[#b0b3b8] hover:bg-[#3a3b3c]">
-              <RiShareForwardLine size={20} />
-              <span className="text-[15px]">Share</span>
-            </button>
+          <div className="mt-3">
+            <PostEngagement
+              likes={likes}
+              commentCount={commentCount}
+              shares={post.shares}
+              liked={liked}
+              onToggleLike={togglePostLike}
+            />
           </div>
 
           <div className="mt-3 flex flex-col gap-4">

--- a/client/components/Content/PhotoTheaterModal.tsx
+++ b/client/components/Content/PhotoTheaterModal.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import ReactDOM from 'react-dom';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { AiFillLike, AiOutlineLike } from 'react-icons/ai';
+import { FaRegComment, FaFacebook } from 'react-icons/fa';
+import { RiShareForwardLine } from 'react-icons/ri';
+import { BsThreeDots } from 'react-icons/bs';
+import { MdPublic } from 'react-icons/md';
+import { RxCross1 } from 'react-icons/rx';
+import cn from 'classnames';
+import { usePostInteractions } from '@hooks/client/usePostInteractions';
+import { useOpenModal } from '@hooks/client/useOpenModal';
+import { useMe } from '@hooks/api/user';
+import HeaderNotification from '@components/header/HeaderNotification';
+import { IPost } from '@types';
+import Comment from './Comment';
+import CommentInput from './CommentInput';
+
+interface PhotoTheaterModalProps {
+  post: IPost;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const PhotoTheaterModal: React.FC<PhotoTheaterModalProps> = ({ post, isOpen, onClose }) => {
+  const { comments, liked, likes, commentCount, addTopLevel, handleReply, toggleCommentLike, togglePostLike } =
+    usePostInteractions(post);
+  const { onModalOpen, onModalClose } = useOpenModal();
+  const { data: user } = useMe();
+  const router = useRouter();
+
+  const goHome = () => {
+    onClose();
+    router.push('/');
+  };
+
+  // Portal targets document.body, which only exists on the client.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Lock body scroll, flag the shared modal state (header reacts to it),
+  // and close on Escape while open.
+  useEffect(() => {
+    if (!isOpen) return;
+    onModalOpen();
+    document.body.style.overflow = 'hidden';
+    document.body.style.paddingRight = '16px';
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleEsc);
+    return () => {
+      onModalClose();
+      document.body.style.overflow = 'auto';
+      document.body.style.paddingRight = '0px';
+      document.removeEventListener('keydown', handleEsc);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen || !mounted) return null;
+
+  return ReactDOM.createPortal(
+    <div className="fixed inset-0 z-[300] flex bg-black">
+      {/* Left: photo on a dark backdrop. Clicking the margin closes. */}
+      <div className="relative flex flex-1 items-center justify-center" onClick={onClose}>
+        {/* Exit + Facebook logo, top-left over the photo */}
+        <div
+          className="absolute left-0 top-0 z-10 flex items-center gap-2 px-4 py-2"
+          onClick={e => e.stopPropagation()}
+        >
+          <button
+            onClick={onClose}
+            className="flex h-10 w-10 items-center justify-center rounded-full bg-[#3a3b3c] text-[#e4e6eb] hover:brightness-125"
+          >
+            <RxCross1 size={20} />
+          </button>
+          <button onClick={goHome} aria-label="Go to homepage" className="hover:brightness-110">
+            <FaFacebook size={40} className="text-[#0866ff]" />
+          </button>
+        </div>
+        {post.image && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={post.image}
+            alt="post"
+            className="max-h-[94vh] max-w-full object-contain"
+            onClick={e => e.stopPropagation()}
+          />
+        )}
+      </div>
+
+      {/* Right: comment sidebar */}
+      <aside className="flex h-screen w-[360px] flex-col bg-[#242526] xl:w-[440px]">
+        {/* Top nav icons — same functional buttons (messages/notifications/profile) as the app header */}
+        {user && (
+          <div className="flex items-center justify-end px-2 py-2 border-b border-[#3e4042]">
+            <HeaderNotification user={user} />
+          </div>
+        )}
+        {/* Author header */}
+        <div className="flex items-center gap-2 p-4 shadow-border-b">
+          <Image
+            src={post.authorAvatar}
+            alt={post.authorName}
+            width={40}
+            height={40}
+            className="h-10 w-10 rounded-full object-cover"
+          />
+          <div className="flex-1">
+            <h4 className="text-[15px] font-semibold text-[#e4e6eb]">{post.authorName}</h4>
+            <p className="flex items-center gap-1 text-[13px] font-light text-[#b0b3b8]">
+              {post.createdAt} · <MdPublic size={12} />
+            </p>
+          </div>
+          <button className="flex h-9 w-9 items-center justify-center rounded-full text-[#b0b3b8] hover:bg-[#3a3b3c]">
+            <BsThreeDots size={20} />
+          </button>
+        </div>
+
+        {/* Scrollable body: caption + counts + actions + comments.
+            min-h-0 lets this flex child shrink and scroll instead of growing
+            to fit all comments — which is what pins the composer to the bottom. */}
+        <div className="min-h-0 flex-1 overflow-y-auto p-4">
+          <p className="text-[15px] text-[#e4e6eb]">{post.content}</p>
+
+          <div className="mt-3 flex items-center justify-between text-[15px] font-light text-[#b0b3b8]">
+            <div className="flex items-center gap-1">
+              <div className="flex h-[18px] w-[18px] items-center justify-center rounded-full bg-[#0780ff]">
+                <AiFillLike className="h-[11px] w-[11px] text-white" />
+              </div>
+              <span>{likes}</span>
+            </div>
+            <div className="flex gap-3">
+              <span>{commentCount} comments</span>
+              <span>{post.shares} shares</span>
+            </div>
+          </div>
+
+          <div className="mt-2 grid grid-cols-3 border-y border-[#3e4042] py-[2px]">
+            <button
+              onClick={togglePostLike}
+              className={cn(
+                'flex w-full items-center justify-center gap-2 rounded-md py-[6px] font-semibold hover:bg-[#3a3b3c]',
+                liked ? 'text-[#0866ff]' : 'text-[#b0b3b8]'
+              )}
+            >
+              {liked ? <AiFillLike size={20} /> : <AiOutlineLike size={20} />}
+              <span className="text-[15px]">Like</span>
+            </button>
+            <button className="flex w-full items-center justify-center gap-2 rounded-md py-[6px] text-[#b0b3b8] hover:bg-[#3a3b3c]">
+              <FaRegComment size={18} />
+              <span className="text-[15px]">Comment</span>
+            </button>
+            <button className="flex w-full items-center justify-center gap-2 rounded-md py-[6px] text-[#b0b3b8] hover:bg-[#3a3b3c]">
+              <RiShareForwardLine size={20} />
+              <span className="text-[15px]">Share</span>
+            </button>
+          </div>
+
+          <div className="mt-3 flex flex-col gap-4">
+            {comments.map(comment => (
+              <Comment key={comment.id} comment={comment} onReply={handleReply} onToggleLike={toggleCommentLike} />
+            ))}
+          </div>
+
+          {/* Composer sits right below the latest comment (flows with the list) */}
+          <div className="mt-4">
+            <CommentInput onSubmit={addTopLevel} placeholder="Write a comment..." />
+          </div>
+        </div>
+      </aside>
+    </div>,
+    document.body
+  );
+};
+
+export default PhotoTheaterModal;

--- a/client/components/Content/Post.tsx
+++ b/client/components/Content/Post.tsx
@@ -1,43 +1,108 @@
 'use client';
 
 import { AiFillLike, AiOutlineLike } from 'react-icons/ai';
-import { TiMessages } from 'react-icons/ti';
+import { FaRegComment } from 'react-icons/fa';
+import { RiShareForwardLine } from 'react-icons/ri';
+import { MdPublic } from 'react-icons/md';
 import Image from 'next/image';
+import cn from 'classnames';
+import { useState } from 'react';
+import { IComment, IPost } from '@types';
 
-interface PostProps {}
-const Post: React.FC<PostProps> = () => {
+interface PostProps {
+  post: IPost;
+  onOpen: () => void;
+}
+
+// Total comments including nested replies.
+const countComments = (comments: IComment[]): number =>
+  comments.reduce((total, c) => total + 1 + countComments(c.replies ?? []), 0);
+
+const Post: React.FC<PostProps> = ({ post, onOpen }) => {
+  const [liked, setLiked] = useState<boolean>(post.isLiked ?? false);
+  const [likes, setLikes] = useState<number>(post.likes);
+
+  const toggleLike = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setLiked(prev => !prev);
+    setLikes(prev => prev + (liked ? -1 : 1));
+  };
+
+  const commentCount = countComments(post.comments);
+
   return (
-    <div className="px-[16px] pt-[12px] rounded-md my-4 bg-[#242526] text-[#b0b3b8]">
+    <div className="my-4 rounded-md bg-[#242526] px-[16px] pt-[12px] text-[#b0b3b8]">
+      {/* Header */}
       <div className="flex items-center gap-2">
-        <div className="w-[40px]">
-          <Image src="/avatar.jpg" alt="" width={40} height={40} className="rounded-full" />
-        </div>
-        <div className="">
-          <h4 className="font-bold text-[15px] text-[#e4e6eb]">Nguyễn Văn An</h4>
-          <p className="font-light text-[13px]">12m</p>
+        <Image
+          src={post.authorAvatar}
+          alt={post.authorName}
+          width={40}
+          height={40}
+          className="h-10 w-10 rounded-full object-cover"
+        />
+        <div>
+          <h4 className="text-[15px] font-bold text-[#e4e6eb]">{post.authorName}</h4>
+          <p className="flex items-center gap-1 text-[13px] font-light">
+            {post.createdAt} · <MdPublic size={12} />
+          </p>
         </div>
       </div>
-      <p className="my-[10px] text-[15px]">Hello how are you</p>
-      <div className="flex justify-between items-center shadow-border-t">
-        <div className="flex items-center py-[10px] gap-1">
-          <div className="ml-[2px] w-[18px] h-[18px] bg-[#0780ff] rounded-full flex justify-center items-center">
-            <AiFillLike className="w-[11px] h-[11px] text-white" />
+
+      {/* Content (click to open modal) */}
+      <div className="cursor-pointer" onClick={onOpen}>
+        <p className="my-[10px] text-[15px] text-[#e4e6eb]">{post.content}</p>
+        {post.image && (
+          <Image
+            src={post.image}
+            alt="post image"
+            width={640}
+            height={360}
+            className="mb-[10px] w-full rounded-lg object-cover"
+            unoptimized
+          />
+        )}
+      </div>
+
+      {/* Counts */}
+      <div className="flex items-center justify-between shadow-border-t">
+        <div className="flex items-center gap-1 py-[10px]">
+          <div className="ml-[2px] flex h-[18px] w-[18px] items-center justify-center rounded-full bg-[#0780ff]">
+            <AiFillLike className="h-[11px] w-[11px] text-white" />
           </div>
-          <p className="text-[15px] font-light">18</p>
+          <p className="text-[15px] font-light">{likes}</p>
         </div>
-        <div className="py-[10px] hover:underline hover:cursor-pointer">
-          <p className="text-[15px] font-light">18 comments</p>
+        <div className="flex gap-3 py-[10px] text-[15px] font-light">
+          <button onClick={onOpen} className="hover:cursor-pointer hover:underline">
+            {commentCount} comments
+          </button>
+          <span>{post.shares} shares</span>
         </div>
       </div>
+
+      {/* Actions */}
       <div className="shadow-border-t py-[4px]">
-        <div className="grid grid-cols-2">
-          <button className="w-full py-[6px] rounded-md flex items-center justify-center gap-2 hover:bg-[#3a3b3c]">
-            <AiOutlineLike size={20} />
+        <div className="grid grid-cols-3">
+          <button
+            onClick={toggleLike}
+            className={cn(
+              'flex w-full items-center justify-center gap-2 rounded-md py-[6px] hover:bg-[#3a3b3c]',
+              liked ? 'text-[#0866ff]' : 'text-[#b0b3b8]'
+            )}
+          >
+            {liked ? <AiFillLike size={20} /> : <AiOutlineLike size={20} />}
             <p className="text-[15px]">Like</p>
           </button>
-          <button className="w-full py-[6px] rounded-md flex items-center justify-center gap-2 hover:bg-[#3a3b3c]">
-            <TiMessages size={20} />
+          <button
+            onClick={onOpen}
+            className="flex w-full items-center justify-center gap-2 rounded-md py-[6px] hover:bg-[#3a3b3c]"
+          >
+            <FaRegComment size={18} />
             <p className="text-[15px]">Comment</p>
+          </button>
+          <button className="flex w-full items-center justify-center gap-2 rounded-md py-[6px] hover:bg-[#3a3b3c]">
+            <RiShareForwardLine size={20} />
+            <p className="text-[15px]">Share</p>
           </button>
         </div>
       </div>

--- a/client/components/Content/PostEngagement.tsx
+++ b/client/components/Content/PostEngagement.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { AiFillLike, AiOutlineLike } from 'react-icons/ai';
+import { FaRegComment } from 'react-icons/fa';
+import { RiShareForwardLine } from 'react-icons/ri';
+import cn from 'classnames';
+
+interface PostEngagementProps {
+  likes: number;
+  commentCount: number;
+  shares: number;
+  liked: boolean;
+  onToggleLike: () => void;
+}
+
+// Reaction counts + Like/Comment/Share bar, shared by PostModal and PhotoTheaterModal.
+const PostEngagement: React.FC<PostEngagementProps> = ({ likes, commentCount, shares, liked, onToggleLike }) => (
+  <div>
+    <div className="flex items-center justify-between text-[15px] font-light text-[#b0b3b8]">
+      <div className="flex items-center gap-1">
+        <div className="flex h-[18px] w-[18px] items-center justify-center rounded-full bg-[#0780ff]">
+          <AiFillLike className="h-[11px] w-[11px] text-white" />
+        </div>
+        <span>{likes}</span>
+      </div>
+      <div className="flex gap-3">
+        <span>{commentCount} comments</span>
+        <span>{shares} shares</span>
+      </div>
+    </div>
+
+    <div className="mt-2 grid grid-cols-3 border-y border-[#3e4042] py-[2px]">
+      <button
+        onClick={onToggleLike}
+        className={cn(
+          'flex w-full items-center justify-center gap-2 rounded-md py-[6px] font-semibold hover:bg-[#3a3b3c]',
+          liked ? 'text-[#0866ff]' : 'text-[#b0b3b8]'
+        )}
+      >
+        {liked ? <AiFillLike size={20} /> : <AiOutlineLike size={20} />}
+        <span className="text-[15px]">Like</span>
+      </button>
+      <button className="flex w-full items-center justify-center gap-2 rounded-md py-[6px] text-[#b0b3b8] hover:bg-[#3a3b3c]">
+        <FaRegComment size={18} />
+        <span className="text-[15px]">Comment</span>
+      </button>
+      <button className="flex w-full items-center justify-center gap-2 rounded-md py-[6px] text-[#b0b3b8] hover:bg-[#3a3b3c]">
+        <RiShareForwardLine size={20} />
+        <span className="text-[15px]">Share</span>
+      </button>
+    </div>
+  </div>
+);
+
+export default PostEngagement;

--- a/client/components/Content/PostModal.tsx
+++ b/client/components/Content/PostModal.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import Image from 'next/image';
+import { AiFillLike, AiOutlineLike } from 'react-icons/ai';
+import { FaRegComment } from 'react-icons/fa';
+import { RiShareForwardLine } from 'react-icons/ri';
+import { BsThreeDots } from 'react-icons/bs';
+import { MdPublic } from 'react-icons/md';
+import cn from 'classnames';
+import Modal from '@components/common/Modal';
+import { usePostInteractions } from '@hooks/client/usePostInteractions';
+import { IPost } from '@types';
+import Comment from './Comment';
+import CommentInput from './CommentInput';
+
+interface PostModalProps {
+  post: IPost;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const PostModal: React.FC<PostModalProps> = ({ post, isOpen, onClose }) => {
+  const { comments, liked, likes, commentCount, addTopLevel, handleReply, toggleCommentLike, togglePostLike } =
+    usePostInteractions(post);
+
+  const footer = <CommentInput onSubmit={addTopLevel} placeholder="Write a comment..." />;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={`${post.authorName}'s post`}
+      footer={footer}
+      widthClassName="w-[700px]"
+      bodyClassName="max-h-[75vh]"
+    >
+      <div className="flex flex-col gap-3">
+        {/* Author */}
+        <div className="flex items-center gap-2">
+          <Image
+            src={post.authorAvatar}
+            alt={post.authorName}
+            width={40}
+            height={40}
+            className="h-10 w-10 rounded-full object-cover"
+          />
+          <div className="flex-1">
+            <h4 className="text-[15px] font-semibold text-[#e4e6eb]">{post.authorName}</h4>
+            <p className="flex items-center gap-1 text-[13px] font-light text-[#b0b3b8]">
+              {post.createdAt} · <MdPublic size={12} />
+            </p>
+          </div>
+          <button className="flex h-9 w-9 items-center justify-center rounded-full text-[#b0b3b8] hover:bg-[#3a3b3c]">
+            <BsThreeDots size={20} />
+          </button>
+        </div>
+
+        {/* Content */}
+        <p className="text-[15px] text-[#e4e6eb]">{post.content}</p>
+
+        {/* Counts */}
+        <div className="flex items-center justify-between text-[15px] font-light text-[#b0b3b8]">
+          <div className="flex items-center gap-1">
+            <div className="flex h-[18px] w-[18px] items-center justify-center rounded-full bg-[#0780ff]">
+              <AiFillLike className="h-[11px] w-[11px] text-white" />
+            </div>
+            <span>{likes}</span>
+          </div>
+          <div className="flex gap-3">
+            <span>{commentCount} comments</span>
+            <span>{post.shares} shares</span>
+          </div>
+        </div>
+
+        {/* Action buttons */}
+        <div className="grid grid-cols-3 border-y border-[#3e4042] py-[2px]">
+          <button
+            onClick={togglePostLike}
+            className={cn(
+              'flex w-full items-center justify-center gap-2 rounded-md py-[6px] font-semibold hover:bg-[#3a3b3c]',
+              liked ? 'text-[#0866ff]' : 'text-[#b0b3b8]'
+            )}
+          >
+            {liked ? <AiFillLike size={20} /> : <AiOutlineLike size={20} />}
+            <span className="text-[15px]">Like</span>
+          </button>
+          <button className="flex w-full items-center justify-center gap-2 rounded-md py-[6px] text-[#b0b3b8] hover:bg-[#3a3b3c]">
+            <FaRegComment size={18} />
+            <span className="text-[15px]">Comment</span>
+          </button>
+          <button className="flex w-full items-center justify-center gap-2 rounded-md py-[6px] text-[#b0b3b8] hover:bg-[#3a3b3c]">
+            <RiShareForwardLine size={20} />
+            <span className="text-[15px]">Share</span>
+          </button>
+        </div>
+
+        {/* Comments */}
+        <div className="flex flex-col gap-4 pt-1">
+          {comments.map(comment => (
+            <Comment key={comment.id} comment={comment} onReply={handleReply} onToggleLike={toggleCommentLike} />
+          ))}
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default PostModal;

--- a/client/components/Content/PostModal.tsx
+++ b/client/components/Content/PostModal.tsx
@@ -1,17 +1,14 @@
 'use client';
 
 import Image from 'next/image';
-import { AiFillLike, AiOutlineLike } from 'react-icons/ai';
-import { FaRegComment } from 'react-icons/fa';
-import { RiShareForwardLine } from 'react-icons/ri';
 import { BsThreeDots } from 'react-icons/bs';
 import { MdPublic } from 'react-icons/md';
-import cn from 'classnames';
 import Modal from '@components/common/Modal';
 import { usePostInteractions } from '@hooks/client/usePostInteractions';
 import { IPost } from '@types';
 import Comment from './Comment';
 import CommentInput from './CommentInput';
+import PostEngagement from './PostEngagement';
 
 interface PostModalProps {
   post: IPost;
@@ -58,41 +55,14 @@ const PostModal: React.FC<PostModalProps> = ({ post, isOpen, onClose }) => {
         {/* Content */}
         <p className="text-[15px] text-[#e4e6eb]">{post.content}</p>
 
-        {/* Counts */}
-        <div className="flex items-center justify-between text-[15px] font-light text-[#b0b3b8]">
-          <div className="flex items-center gap-1">
-            <div className="flex h-[18px] w-[18px] items-center justify-center rounded-full bg-[#0780ff]">
-              <AiFillLike className="h-[11px] w-[11px] text-white" />
-            </div>
-            <span>{likes}</span>
-          </div>
-          <div className="flex gap-3">
-            <span>{commentCount} comments</span>
-            <span>{post.shares} shares</span>
-          </div>
-        </div>
-
-        {/* Action buttons */}
-        <div className="grid grid-cols-3 border-y border-[#3e4042] py-[2px]">
-          <button
-            onClick={togglePostLike}
-            className={cn(
-              'flex w-full items-center justify-center gap-2 rounded-md py-[6px] font-semibold hover:bg-[#3a3b3c]',
-              liked ? 'text-[#0866ff]' : 'text-[#b0b3b8]'
-            )}
-          >
-            {liked ? <AiFillLike size={20} /> : <AiOutlineLike size={20} />}
-            <span className="text-[15px]">Like</span>
-          </button>
-          <button className="flex w-full items-center justify-center gap-2 rounded-md py-[6px] text-[#b0b3b8] hover:bg-[#3a3b3c]">
-            <FaRegComment size={18} />
-            <span className="text-[15px]">Comment</span>
-          </button>
-          <button className="flex w-full items-center justify-center gap-2 rounded-md py-[6px] text-[#b0b3b8] hover:bg-[#3a3b3c]">
-            <RiShareForwardLine size={20} />
-            <span className="text-[15px]">Share</span>
-          </button>
-        </div>
+        {/* Counts + action bar */}
+        <PostEngagement
+          likes={likes}
+          commentCount={commentCount}
+          shares={post.shares}
+          liked={liked}
+          onToggleLike={togglePostLike}
+        />
 
         {/* Comments */}
         <div className="flex flex-col gap-4 pt-1">

--- a/client/components/Content/Shortcut.tsx
+++ b/client/components/Content/Shortcut.tsx
@@ -18,25 +18,23 @@ const Shortcut: React.FC<ShortcutProps> = () => {
   if (!user) return null;
 
   return (
-    <div className="">
-      <div className="w-1/4 p-[6px] mt-[60px] text-[#b0b3b8] font-bold text-[15px] fixed top-0">
-        <div className="flex items-center gap-2 mt-[10px] p-2 rounded-lg hover:bg-[#3a3b3c] hover:cursor-pointer">
-          <div className="w-[36px]">
-            <Image src={user.avatar} alt="" width={36} height={36} className="rounded-full" />
-          </div>
-          <p className="text-[#e4e6eb]">{user.fullName}</p>
+    <aside className="hidden lg:block w-[300px] shrink-0 self-start sticky top-[56px] max-h-[calc(100vh-56px)] overflow-y-auto py-4 pl-4 text-[#b0b3b8] font-bold text-[15px]">
+      <div className="flex items-center gap-2 p-2 rounded-lg hover:bg-[#3a3b3c] hover:cursor-pointer">
+        <div className="w-[36px]">
+          <Image src={user.avatar} alt="" width={36} height={36} className="rounded-full" />
         </div>
-        <div
-          onClick={goToFriends}
-          className="flex items-center gap-2 mt-[6px] p-2 rounded-lg hover:bg-[#3a3b3c] hover:cursor-pointer"
-        >
-          <div className="w-[40px]">
-            <div className="bg-[url('/shortcut-icon.png')] shortcut-friend-icon"></div>
-          </div>
-          <p>Friends</p>
-        </div>
+        <p className="text-[#e4e6eb]">{user.fullName}</p>
       </div>
-    </div>
+      <div
+        onClick={goToFriends}
+        className="flex items-center gap-2 mt-[6px] p-2 rounded-lg hover:bg-[#3a3b3c] hover:cursor-pointer"
+      >
+        <div className="w-[40px]">
+          <div className="bg-[url('/shortcut-icon.png')] shortcut-friend-icon"></div>
+        </div>
+        <p>Friends</p>
+      </div>
+    </aside>
   );
 };
 

--- a/client/components/Header/MessageList.tsx
+++ b/client/components/Header/MessageList.tsx
@@ -4,7 +4,7 @@ interface MessageListProps {}
 
 const MessageList: React.FC<MessageListProps> = () => {
   return (
-    <div className="fixed top-[57px] bottom-[50px] rounded-md shadow-md right-[50px] w-[360px] bg-[#242526] text-[#b0b3b8] px-[8px] pt-[16px] pb-[32px]">
+    <div className="fixed top-[57px] bottom-[50px] rounded-md border border-[#3e4042] shadow-2xl right-[50px] w-[360px] bg-[#242526] text-[#b0b3b8] px-[8px] pt-[16px] pb-[32px]">
       <div className="overflow-y-scroll h-full">
         <h3 className="text-[24px] font-bold text-[#e4e6eb] px-[6px]">Chats</h3>
         <div className="mt-4 h-full">

--- a/client/components/Header/NotificationList.tsx
+++ b/client/components/Header/NotificationList.tsx
@@ -4,7 +4,7 @@ interface NotificationListProps {}
 
 const NotificationList: React.FC<NotificationListProps> = () => {
   return (
-    <div className="fixed top-[57px] bottom-[50px] rounded-md shadow-md right-[20px] w-[360px] bg-[#242526] text-[#b0b3b8] px-[8px] pt-[16px] pb-[32px]">
+    <div className="fixed top-[57px] bottom-[50px] rounded-md border border-[#3e4042] shadow-2xl right-[20px] w-[360px] bg-[#242526] text-[#b0b3b8] px-[8px] pt-[16px] pb-[32px]">
       <div className="overflow-y-scroll h-full">
         <h3 className="text-[24px] font-bold text-[#e4e6eb] px-[6px]">Notifications</h3>
         <div className="mt-4 h-full">

--- a/client/components/Header/ProfileDropdown.tsx
+++ b/client/components/Header/ProfileDropdown.tsx
@@ -29,7 +29,7 @@ const ProfileDropdown: React.FC<ProfileDropdownProps> = ({ user, onOpen }) => {
   }, [isError, isSuccess]);
 
   return (
-    <div className="fixed top-[57px] rounded-md shadow-md right-[20px] w-[360px] bg-[#242526] text-[#b0b3b8] p-[8px]">
+    <div className="fixed top-[57px] rounded-md border border-[#3e4042] shadow-2xl right-[20px] w-[360px] bg-[#242526] text-[#b0b3b8] p-[8px]">
       <Link
         href={`/${user.id}`}
         onClick={() => {

--- a/client/components/Profile/Posts.tsx
+++ b/client/components/Profile/Posts.tsx
@@ -1,19 +1,35 @@
 'use client';
 
+import { useState } from 'react';
 import Post from '@components/content/Post';
+import PostModal from '@components/content/PostModal';
+import PhotoTheaterModal from '@components/content/PhotoTheaterModal';
+import { posts } from '@mock/posts';
+import { IPost } from '@types';
 
 interface PostsProps {}
 const Posts: React.FC<PostsProps> = () => {
+  const [selectedPost, setSelectedPost] = useState<IPost | null>(null);
+
+  const close = () => setSelectedPost(null);
+
   return (
     <div className="text-[#e4e6eb] w-3/5">
       <div className="bg-[#242526] py-[12px] px-[16px] rounded-md">
         <h3 className="text-[20px] font-bold">Posts</h3>
       </div>
       <div>
-        <Post />
-        <Post />
-        <Post />
+        {posts.map(post => (
+          <Post key={post.id} post={post} onOpen={() => setSelectedPost(post)} />
+        ))}
       </div>
+
+      {selectedPost &&
+        (selectedPost.image ? (
+          <PhotoTheaterModal post={selectedPost} isOpen onClose={close} />
+        ) : (
+          <PostModal post={selectedPost} isOpen onClose={close} />
+        ))}
     </div>
   );
 };

--- a/client/components/Profile/Posts.tsx
+++ b/client/components/Profile/Posts.tsx
@@ -26,9 +26,9 @@ const Posts: React.FC<PostsProps> = () => {
 
       {selectedPost &&
         (selectedPost.image ? (
-          <PhotoTheaterModal post={selectedPost} isOpen onClose={close} />
+          <PhotoTheaterModal key={selectedPost.id} post={selectedPost} isOpen onClose={close} />
         ) : (
-          <PostModal post={selectedPost} isOpen onClose={close} />
+          <PostModal key={selectedPost.id} post={selectedPost} isOpen onClose={close} />
         ))}
     </div>
   );

--- a/client/components/common/Modal.tsx
+++ b/client/components/common/Modal.tsx
@@ -1,5 +1,5 @@
 import { useOpenModal } from '@hooks/client/useOpenModal';
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { RxCross1 } from 'react-icons/rx';
 
@@ -9,11 +9,29 @@ interface ModalProps {
   title: string;
   children: React.ReactNode;
   footer: React.ReactNode;
+  widthClassName?: string;
+  bodyClassName?: string;
 }
 
-const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, footer }) => {
+const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  onClose,
+  title,
+  children,
+  footer,
+  widthClassName = 'w-[700px]',
+  bodyClassName = 'max-h-[480px]'
+}) => {
   const modalRef = useRef<HTMLDivElement>(null);
   const { onModalOpen, onModalClose } = useOpenModal();
+
+  // The portal targets document.body, which only exists in the browser.
+  // Rendering it during SSR / the first hydration pass causes a mismatch,
+  // so we wait until the component has mounted on the client.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   useEffect(() => {
     if (isOpen) {
@@ -57,11 +75,11 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, footer 
     };
   }, [isOpen, onClose]);
 
-  if (!isOpen) return null;
+  if (!isOpen || !mounted) return null;
 
   return ReactDOM.createPortal(
     <div className="fixed top-0 left-0 right-0 bottom-0 modal bg-black bg-opacity-70 flex justify-center items-center z-[200]">
-      <div ref={modalRef} className="bg-[#252728] rounded-lg shadow-border w-[700px] relative">
+      <div ref={modalRef} className={`bg-[#252728] rounded-lg shadow-border max-w-[95vw] ${widthClassName} relative`}>
         <div className="flex items-center py-4 shadow-border-b">
           <div className="w-[48px]" />
           <h2 className="flex-grow text-center text-[20px] font-bold text-[#e2e5e9]">{title}</h2>
@@ -74,7 +92,7 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, footer 
             </button>
           </div>
         </div>
-        <div className="p-4 max-h-[480px] overflow-y-auto">{children}</div>
+        <div className={`p-4 overflow-y-auto ${bodyClassName}`}>{children}</div>
         <div className="p-4 shadow-border-t">{footer}</div>
       </div>
     </div>,

--- a/client/hooks/client/usePostInteractions.ts
+++ b/client/hooks/client/usePostInteractions.ts
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { IComment, IPost } from '@types';
+
+// Count every comment plus all nested replies.
+const countComments = (comments: IComment[]): number =>
+  comments.reduce((total, c) => total + 1 + countComments(c.replies ?? []), 0);
+
+// Immutably insert a reply under the comment whose id === parentId.
+const insertReply = (comments: IComment[], parentId: string, reply: IComment): IComment[] =>
+  comments.map(c => {
+    if (c.id === parentId) {
+      return { ...c, replies: [...(c.replies ?? []), reply] };
+    }
+    if (c.replies?.length) {
+      return { ...c, replies: insertReply(c.replies, parentId, reply) };
+    }
+    return c;
+  });
+
+// Immutably toggle the like flag/count on the comment whose id matches.
+const toggleLikeById = (comments: IComment[], id: string): IComment[] =>
+  comments.map(c => {
+    if (c.id === id) {
+      const isLiked = !c.isLiked;
+      return { ...c, isLiked, likes: c.likes + (isLiked ? 1 : -1) };
+    }
+    if (c.replies?.length) {
+      return { ...c, replies: toggleLikeById(c.replies, id) };
+    }
+    return c;
+  });
+
+// Shared in-session interaction state for a post (likes + comment tree).
+// Used by both the centered text-post modal and the photo theater modal.
+export const usePostInteractions = (post: IPost) => {
+  const [comments, setComments] = useState<IComment[]>(post.comments);
+  const [liked, setLiked] = useState<boolean>(post.isLiked ?? false);
+  const [likes, setLikes] = useState<number>(post.likes);
+
+  const makeComment = (content: string): IComment => ({
+    id: crypto.randomUUID(),
+    authorName: 'You',
+    authorAvatar: '/avatar.jpg',
+    content,
+    createdAt: 'Just now',
+    likes: 0
+  });
+
+  const addTopLevel = (content: string) => {
+    setComments(prev => [...prev, makeComment(content)]);
+  };
+
+  const handleReply = (parentId: string, content: string) => {
+    setComments(prev => insertReply(prev, parentId, makeComment(content)));
+  };
+
+  const toggleCommentLike = (id: string) => {
+    setComments(prev => toggleLikeById(prev, id));
+  };
+
+  const togglePostLike = () => {
+    setLiked(prev => !prev);
+    setLikes(prev => prev + (liked ? -1 : 1));
+  };
+
+  return {
+    comments,
+    liked,
+    likes,
+    commentCount: countComments(comments),
+    addTopLevel,
+    handleReply,
+    toggleCommentLike,
+    togglePostLike
+  };
+};

--- a/client/mock/posts.ts
+++ b/client/mock/posts.ts
@@ -1,0 +1,143 @@
+import { IPost } from '@types';
+
+// Static mock data for the post feed UI. No backend involved.
+// All body text is lorem-ipsum placeholder — intentionally nonsense.
+const AVATAR = '/avatar.jpg';
+const PHOTO = '/background.png';
+
+export const posts: IPost[] = [
+  {
+    id: 'p1',
+    authorName: 'Lorem Ipsum',
+    authorAvatar: AVATAR,
+    createdAt: '12m',
+    content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore.',
+    likes: 128,
+    shares: 7,
+    comments: [
+      {
+        id: 'c1',
+        authorName: 'Dolor Sit',
+        authorAvatar: AVATAR,
+        content: 'Ut enim ad minim veniam, quis nostrud exercitation ullamco.',
+        createdAt: '8m',
+        likes: 12,
+        replies: [
+          {
+            id: 'c1-r1',
+            authorName: 'Lorem Ipsum',
+            authorAvatar: AVATAR,
+            content: 'Duis aute irure dolor in reprehenderit in voluptate velit.',
+            createdAt: '6m',
+            likes: 3,
+            replies: [
+              {
+                id: 'c1-r1-r1',
+                authorName: 'Dolor Sit',
+                authorAvatar: AVATAR,
+                content: 'Excepteur sint occaecat cupidatat non proident.',
+                createdAt: '4m',
+                likes: 1
+              }
+            ]
+          },
+          {
+            id: 'c1-r2',
+            authorName: 'Amet Consectetur',
+            authorAvatar: AVATAR,
+            content: 'Sunt in culpa qui officia deserunt mollit anim id est laborum.',
+            createdAt: '3m',
+            likes: 5
+          }
+        ]
+      },
+      {
+        id: 'c2',
+        authorName: 'Adipiscing Elit',
+        authorAvatar: AVATAR,
+        content: 'Nemo enim ipsam voluptatem quia voluptas sit aspernatur.',
+        createdAt: '5m',
+        likes: 2
+      }
+    ]
+  },
+  {
+    id: 'p2',
+    authorName: 'Dolor Sit',
+    authorAvatar: AVATAR,
+    createdAt: '1h',
+    content: 'Neque porro quisquam est qui dolorem ipsum quia dolor sit amet 📷',
+    image: PHOTO,
+    likes: 342,
+    shares: 21,
+    comments: [
+      {
+        id: 'c3',
+        authorName: 'Lorem Ipsum',
+        authorAvatar: AVATAR,
+        content: 'Quis autem vel eum iure reprehenderit qui in ea voluptate.',
+        createdAt: '50m',
+        likes: 8,
+        replies: [
+          {
+            id: 'c3-r1',
+            authorName: 'Dolor Sit',
+            authorAvatar: AVATAR,
+            content: 'At vero eos et accusamus et iusto odio dignissimos.',
+            createdAt: '45m',
+            likes: 2
+          }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'p3',
+    authorName: 'Amet Consectetur',
+    authorAvatar: AVATAR,
+    createdAt: '3h',
+    content: 'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium?',
+    likes: 56,
+    shares: 3,
+    comments: [
+      {
+        id: 'c4',
+        authorName: 'Adipiscing Elit',
+        authorAvatar: AVATAR,
+        content: 'Totam rem aperiam, eaque ipsa quae ab illo inventore veritatis.',
+        createdAt: '2h',
+        likes: 15,
+        replies: [
+          {
+            id: 'c4-r1',
+            authorName: 'Amet Consectetur',
+            authorAvatar: AVATAR,
+            content: 'Et quasi architecto beatae vitae dicta sunt explicabo 👍',
+            createdAt: '1h',
+            likes: 4
+          }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'p4',
+    authorName: 'Adipiscing Elit',
+    authorAvatar: AVATAR,
+    createdAt: '5h',
+    content: 'Consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt 🌄',
+    image: PHOTO,
+    likes: 210,
+    shares: 11,
+    comments: [
+      {
+        id: 'c5',
+        authorName: 'Lorem Ipsum',
+        authorAvatar: AVATAR,
+        content: 'Neque porro quisquam est qui dolorem ipsum quia dolor.',
+        createdAt: '4h',
+        likes: 6
+      }
+    ]
+  }
+];

--- a/client/tailwind.config.ts
+++ b/client/tailwind.config.ts
@@ -8,6 +8,10 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      screens: {
+        '3xl': '1800px',
+        '4xl': '2400px'
+      },
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
         'gradient-conic': 'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))'

--- a/client/types/index.ts
+++ b/client/types/index.ts
@@ -2,3 +2,4 @@ export * from './user';
 export * from './response';
 export * from './payload';
 export * from './notification';
+export * from './post';

--- a/client/types/post.ts
+++ b/client/types/post.ts
@@ -1,0 +1,23 @@
+export interface IComment {
+  id: string;
+  authorName: string;
+  authorAvatar: string;
+  content: string;
+  createdAt: string; // relative label for static UI, e.g. "2h"
+  likes: number;
+  isLiked?: boolean;
+  replies?: IComment[];
+}
+
+export interface IPost {
+  id: string;
+  authorName: string;
+  authorAvatar: string;
+  createdAt: string; // relative label for static UI, e.g. "12m"
+  content: string;
+  image?: string;
+  likes: number;
+  isLiked?: boolean;
+  shares: number;
+  comments: IComment[];
+}


### PR DESCRIPTION
## Summary
- Data-driven Facebook-style post cards that open on click
- Text posts open a centered popup (`PostModal`); image posts open a full-screen photo theater (`PhotoTheaterModal`)
- Theater top bar: exit (leftmost) + Facebook logo that navigates home; the comment side reuses the functional `HeaderNotification` dropdowns (messages/notifications/profile) with a separator line; comment composer flows below the latest comment
- Recursive nested comments (`Comment`) with Facebook-style bubbles, Like/Reply, indented threaded replies; in-session interactivity via a shared `usePostInteractions` hook
- Lorem-ipsum placeholder mock data + `IPost`/`IComment` types
- News feed layout: centered feed column with sticky left/right rails and balanced edge padding
- Friends "People you may know" grid made responsive via new `3xl`/`4xl` Tailwind breakpoints
- Global scrollbar restyle (thin, rounded, subtle dark thumb)
- Shared `Modal` made size-configurable (width/body height) + mount guard to fix a portal hydration error
- Dropdown popups (notifications/messages/profile) get a light border + stronger shadow

## Notes
- Frontend-only / static UI — no backend changes

## Jira
[FAK-20](https://nguyenphatdat3004.atlassian.net/browse/FAK-20)

[FAK-20]: https://nguyenphatdat3004.atlassian.net/browse/FAK-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ