### PR TITLE
[FAK-7] [User] Password hash leaked in responses + unbounded findAll

### DIFF
--- a/api-gateway/proto/user.proto
+++ b/api-gateway/proto/user.proto
@@ -5,7 +5,7 @@ package user;
 service UserService {
     rpc CreateUser (CreateUserDto) returns (UserResponse) {}
     rpc Login (LoginDto) returns (UserResponse) {}
-    rpc FindAllUsers (Empty) returns (UsersResponse) {}
+    rpc FindAllUsers (PaginationDto) returns (UsersResponse) {}
     rpc FindOneUser (FindOneUserDto) returns (UserResponse) {}
     rpc UpdateUser (UpdateUserRequest) returns (UserResponse) {}
     rpc UpdateUserImage (UpdateUserImageRequest) returns (UserResponse) {}
@@ -61,7 +61,7 @@ message StatusResponse {
 
 message PaginationDto {
     int32 page = 1;
-    int32 skip = 2;
+    int32 limit = 2;
 }
 
 message UpdateUserRequest {

--- a/api-gateway/proto/user.ts
+++ b/api-gateway/proto/user.ts
@@ -58,7 +58,7 @@ export interface StatusResponse {
 
 export interface PaginationDto {
   page: number;
-  skip: number;
+  limit: number;
 }
 
 export interface UpdateUserRequest {
@@ -129,7 +129,7 @@ export interface UserServiceClient {
 
   login(request: LoginDto): Observable<UserResponse>;
 
-  findAllUsers(request: Empty): Observable<UsersResponse>;
+  findAllUsers(request: PaginationDto): Observable<UsersResponse>;
 
   findOneUser(request: FindOneUserDto): Observable<UserResponse>;
 
@@ -151,7 +151,7 @@ export interface UserServiceController {
 
   login(request: LoginDto): Promise<UserResponse> | Observable<UserResponse> | UserResponse;
 
-  findAllUsers(request: Empty): Promise<UsersResponse> | Observable<UsersResponse> | UsersResponse;
+  findAllUsers(request: PaginationDto): Promise<UsersResponse> | Observable<UsersResponse> | UsersResponse;
 
   findOneUser(request: FindOneUserDto): Promise<UserResponse> | Observable<UserResponse> | UserResponse;
 

--- a/api-gateway/src/user/user.controller.ts
+++ b/api-gateway/src/user/user.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   Param,
   Patch,
+  Query,
   Post,
   UploadedFile,
   UseGuards,
@@ -27,8 +28,8 @@ export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @Get('')
-  getAll() {
-    return this.userService.getAll();
+  getAll(@Query('page') page?: string, @Query('limit') limit?: string) {
+    return this.userService.getAll(Number(page) || 0, Number(limit) || 0);
   }
 
   @Get('me')

--- a/api-gateway/src/user/user.service.ts
+++ b/api-gateway/src/user/user.service.ts
@@ -17,8 +17,8 @@ export class UserService implements OnModuleInit {
     this.grpcService = this.client.getService<UserServiceClient>(USER_SERVICE_NAME);
   }
 
-  async getAll() {
-    const response = await lastValueFrom(this.grpcService.findAllUsers({}));
+  async getAll(page = 0, limit = 0) {
+    const response = await lastValueFrom(this.grpcService.findAllUsers({ page, limit }));
     if (!response.success) throw new BadRequestException(response.message);
     return response.data;
   }

--- a/user-service/proto/user.proto
+++ b/user-service/proto/user.proto
@@ -5,7 +5,7 @@ package user;
 service UserService {
     rpc CreateUser (CreateUserDto) returns (UserResponse) {}
     rpc Login (LoginDto) returns (UserResponse) {}
-    rpc FindAllUsers (Empty) returns (UsersResponse) {}
+    rpc FindAllUsers (PaginationDto) returns (UsersResponse) {}
     rpc FindOneUser (FindOneUserDto) returns (UserResponse) {}
     rpc UpdateUser (UpdateUserRequest) returns (UserResponse) {}
     rpc UpdateUserImage (UpdateUserImageRequest) returns (UserResponse) {}
@@ -61,7 +61,7 @@ message StatusResponse {
 
 message PaginationDto {
     int32 page = 1;
-    int32 skip = 2;
+    int32 limit = 2;
 }
 
 message UpdateUserRequest {

--- a/user-service/proto/user.ts
+++ b/user-service/proto/user.ts
@@ -58,7 +58,7 @@ export interface StatusResponse {
 
 export interface PaginationDto {
   page: number;
-  skip: number;
+  limit: number;
 }
 
 export interface UpdateUserRequest {
@@ -129,7 +129,7 @@ export interface UserServiceClient {
 
   login(request: LoginDto): Observable<UserResponse>;
 
-  findAllUsers(request: Empty): Observable<UsersResponse>;
+  findAllUsers(request: PaginationDto): Observable<UsersResponse>;
 
   findOneUser(request: FindOneUserDto): Observable<UserResponse>;
 
@@ -151,7 +151,7 @@ export interface UserServiceController {
 
   login(request: LoginDto): Promise<UserResponse> | Observable<UserResponse> | UserResponse;
 
-  findAllUsers(request: Empty): Promise<UsersResponse> | Observable<UsersResponse> | UsersResponse;
+  findAllUsers(request: PaginationDto): Promise<UsersResponse> | Observable<UsersResponse> | UsersResponse;
 
   findOneUser(request: FindOneUserDto): Promise<UserResponse> | Observable<UserResponse> | UserResponse;
 

--- a/user-service/src/user/user.controller.ts
+++ b/user-service/src/user/user.controller.ts
@@ -6,6 +6,7 @@ import {
   UserServiceControllerMethods,
   FindOneUserDto,
   LoginDto,
+  PaginationDto,
   UpdateUserRequest,
   UpdateUserImageRequest,
   SendFriendRequestDto,
@@ -26,8 +27,8 @@ export class UserController implements UserServiceController {
     return this.userService.login(loginDto);
   }
 
-  findAllUsers() {
-    return this.userService.findAll();
+  findAllUsers(paginationDto: PaginationDto) {
+    return this.userService.findAll(paginationDto);
   }
 
   findOneUser(findOneUserDto: FindOneUserDto) {

--- a/user-service/src/user/user.service.ts
+++ b/user-service/src/user/user.service.ts
@@ -1,4 +1,4 @@
-import { CreateUserDto, LoginDto, UpdateUserDto, UpdateUserImageDto, UserResponse } from '@proto/user';
+import { CreateUserDto, LoginDto, PaginationDto, UpdateUserDto, UpdateUserImageDto, UserResponse } from '@proto/user';
 import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { ConfigService } from '@nestjs/config';
@@ -33,6 +33,13 @@ export class UserService implements OnModuleInit {
     } finally {
       await session.close();
     }
+  }
+
+  /** Strip the argon2 `password` hash from a Neo4j node's properties before it leaves the service. */
+  private sanitize(properties: Record<string, any>) {
+    if (!properties) return properties;
+    const { password, ...rest } = properties;
+    return rest;
   }
 
   async findByUsername(username: string) {
@@ -113,11 +120,17 @@ export class UserService implements OnModuleInit {
     }
   }
 
-  async findAll() {
+  async findAll(pagination?: PaginationDto) {
     const session = this.driver.session();
     try {
-      const result = await session.run('MATCH (user:USER) RETURN user;');
-      const users = result.records.map(record => record.get('user').properties);
+      const page = Math.max(1, pagination?.page || 1);
+      const limit = Math.min(100, Math.max(1, pagination?.limit || 20));
+      const skip = (page - 1) * limit;
+      const result = await session.run(
+        'MATCH (user:USER) RETURN user ORDER BY user.createdDate SKIP $skip LIMIT $limit;',
+        { skip: neo4j.int(skip), limit: neo4j.int(limit) }
+      );
+      const users = result.records.map(record => this.sanitize(record.get('user').properties));
       return formattedResponse('success', undefined, users);
     } catch (error) {
       console.log({ error });
@@ -134,7 +147,7 @@ export class UserService implements OnModuleInit {
 
       const records = result.records;
       if (records.length === 0) return formattedResponse('fail');
-      return formattedResponse('success', undefined, records[0].get(0).properties);
+      return formattedResponse('success', undefined, this.sanitize(records[0].get(0).properties));
     } catch (error) {
       console.log({ error });
       return formattedResponse('fail');
@@ -157,7 +170,7 @@ export class UserService implements OnModuleInit {
       if (records.length === 0) return formattedResponse('fail');
       if (updateUserDto.fullName)
         this.notificationClient.emit('update-user', new UpdateUserEvent(id, updateUserDto.fullName, null));
-      return formattedResponse('success', undefined, records[0].get(0).properties);
+      return formattedResponse('success', undefined, this.sanitize(records[0].get(0).properties));
     } catch (error) {
       console.log({ error });
       return formattedResponse('fail');
@@ -183,7 +196,7 @@ export class UserService implements OnModuleInit {
       if (records.length === 0) return formattedResponse('fail');
       this.wsClient.emit('image-ready', { userId, imageUrl: url, type });
       if (type === 'avatar') this.notificationClient.emit('update-user', new UpdateUserEvent(userId, null, url));
-      return formattedResponse('success', undefined, records[0].get('u').properties);
+      return formattedResponse('success', undefined, this.sanitize(records[0].get('u').properties));
     } catch (error) {
       console.error({ error });
       return formattedResponse('fail');
@@ -208,7 +221,7 @@ export class UserService implements OnModuleInit {
         { userId }
       );
 
-      const users = result.records.map(record => record.get('user').properties);
+      const users = result.records.map(record => this.sanitize(record.get('user').properties));
       return formattedResponse('success', undefined, users);
     } catch (error) {
       console.error({ error });


### PR DESCRIPTION
## Summary
- **Stop leaking the password hash.** Added `UserService.sanitize()` and applied it to every read/write path that returns a Neo4j `USER` node (`findOne`, `findAll`, `getFriendSuggestions`, `update`, `updateImage`). `create`/`login` already stripped it; `findByUsername` intentionally keeps it since `login`/`create` need the hash for argon2 verification.
- **Bound `findAll`.** Replaced the unbounded `MATCH (user:USER) RETURN user` with `SKIP/LIMIT` pagination (default page size 20, capped at 100, ordered by `createdDate`).
- **Threaded pagination through the contract.** `FindAllUsers` now takes `PaginationDto { page, limit }` instead of `Empty`; gateway `GET /api/user` accepts `?page=` & `?limit=` query params. Updated both `proto/user.proto` copies and their committed generated `proto/user.ts` (the `proto:gen` script is Windows-only, so generated files were hand-edited to match).

## Jira
[FAK-7](https://nguyenphatdat3004.atlassian.net/browse/FAK-7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FAK-7]: https://nguyenphatdat3004.atlassian.net/browse/FAK-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ