### PR TITLE
[FAK-4] [Gateway] Broken authorization (IDOR): actor identity taken from URL, not JWT

### DIFF
--- a/api-gateway/src/user/user.controller.ts
+++ b/api-gateway/src/user/user.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  ForbiddenException,
   Get,
   Param,
   Patch,
@@ -38,37 +39,65 @@ export class UserController {
   }
 
   @Patch(':id')
-  update(@Param('id') userId: string, @Body() updateUserDto: UpdateUserDto) {
-    return this.userService.update(userId, updateUserDto);
+  update(@Param('id') userId: string, @GetUser() user: TokenPayload, @Body() updateUserDto: UpdateUserDto) {
+    this.assertSelf(userId, user);
+    return this.userService.update(user.id, updateUserDto);
   }
 
   @Post('/image/:id')
   @UseInterceptors(FileInterceptor('image', { storage: memoryStorage() }))
   async updateImage(
     @Param('id') userId: string,
+    @GetUser() user: TokenPayload,
     @UploadedFile() image: Express.Multer.File,
     @Body() updateUserImage: UpdateUserImageDto //used for post newfeeds
   ) {
-    return this.userService.updateImage(userId, image, updateUserImage.type);
+    this.assertSelf(userId, user);
+    return this.userService.updateImage(user.id, image, updateUserImage.type);
   }
 
   @Get('/friend-suggestions/:id')
-  async getFriendSuggestions(@Param('id') userId: string) {
-    return this.userService.getFriendSuggestions(userId);
+  async getFriendSuggestions(@Param('id') userId: string, @GetUser() user: TokenPayload) {
+    this.assertSelf(userId, user);
+    return this.userService.getFriendSuggestions(user.id);
   }
 
   @Post('/send-friend-request/:id')
-  async sendFriendRequest(@Param('id') userId: string, @Body() body: AddFriendRequestDto) {
-    return this.userService.sendFriendRequest(userId, body.friendId);
+  async sendFriendRequest(
+    @Param('id') userId: string,
+    @GetUser() user: TokenPayload,
+    @Body() body: AddFriendRequestDto
+  ) {
+    this.assertSelf(userId, user);
+    return this.userService.sendFriendRequest(user.id, body.friendId);
   }
 
   @Post('/accept-friend-request/:id')
-  async acceptFriendRequest(@Param('id') userId: string, @Body() body: AddFriendRequestDto) {
-    return this.userService.acceptFriendRequest(userId, body.friendId);
+  async acceptFriendRequest(
+    @Param('id') userId: string,
+    @GetUser() user: TokenPayload,
+    @Body() body: AddFriendRequestDto
+  ) {
+    this.assertSelf(userId, user);
+    return this.userService.acceptFriendRequest(user.id, body.friendId);
   }
 
   @Post('/decline-friend-request/:id')
-  async declineFriendRequest(@Param('id') userId: string, @Body() body: AddFriendRequestDto) {
-    return this.userService.declineFriendRequest(userId, body.friendId);
+  async declineFriendRequest(
+    @Param('id') userId: string,
+    @GetUser() user: TokenPayload,
+    @Body() body: AddFriendRequestDto
+  ) {
+    this.assertSelf(userId, user);
+    return this.userService.declineFriendRequest(user.id, body.friendId);
+  }
+
+  // The actor is always the authenticated user (JWT). The path `:id` is the
+  // claimed actor/resource owner; reject any request where it does not match
+  // the JWT identity to prevent IDOR (acting as another user via the URL).
+  private assertSelf(targetId: string, user: TokenPayload) {
+    if (targetId !== user.id) {
+      throw new ForbiddenException('You can only perform this action as yourself');
+    }
   }
 }


### PR DESCRIPTION
## Summary
- The user controller derived the **acting user from the URL `:id`** for `PATCH /:id`, `POST /image/:id`, and all friend-request routes (`send`/`accept`/`decline`), plus `GET /friend-suggestions/:id`. The JWT identity was only used by `GET /me`. Any authenticated user could edit any profile, upload images as anyone, and send/accept/decline friend requests as anyone by changing the URL `:id` (IDOR).
- Now the actor is always derived from the JWT via `@GetUser()`. The path `:id` is treated as the *claimed* actor/owner and authorized against the JWT identity — mismatches return `403 Forbidden` (`assertSelf`). The genuine other party (`body.friendId`) is still passed through as the target.
- API URL shape is unchanged, so existing clients (which already send the logged-in user's own id) keep working.

## Jira
[FAK-4](https://nguyenphatdat3004.atlassian.net/browse/FAK-4)

[FAK-4]: https://nguyenphatdat3004.atlassian.net/browse/FAK-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ